### PR TITLE
Cleaning oracle-jdk cache as proposed in dockerfile/java#13

### DIFF
--- a/oracle-java6/Dockerfile
+++ b/oracle-java6/Dockerfile
@@ -14,7 +14,8 @@ RUN \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update && \
   apt-get install -y oracle-java6-installer && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk6-installer
 
 # Define working directory.
 WORKDIR /data

--- a/oracle-java7/Dockerfile
+++ b/oracle-java7/Dockerfile
@@ -14,7 +14,8 @@ RUN \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update && \
   apt-get install -y oracle-java7-installer && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk7-installer
 
 # Define working directory.
 WORKDIR /data

--- a/oracle-java8/Dockerfile
+++ b/oracle-java8/Dockerfile
@@ -14,7 +14,9 @@ RUN \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update && \
   apt-get install -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
+
 
 # Define working directory.
 WORKDIR /data


### PR DESCRIPTION
Tested builds locally. Sizes of oracle java images reduced to ~750mb
